### PR TITLE
add support for callable

### DIFF
--- a/spec/rtens/mockster/MockMethodsTest.php
+++ b/spec/rtens/mockster/MockMethodsTest.php
@@ -230,4 +230,33 @@ class MockMethodsTest extends Specification {
         $this->fixture->thenItsProperty_ShouldBe('called', 0);
     }
 
+    /**
+     * @dataProvider typehintProvider
+     */
+    public function testMockTypehints($typehint, $value) {
+        $className = 'Typehint' . str_replace('\\', '', $typehint);
+        $this->fixture->givenTheClassDefinition('
+            class ' . $className . ' {
+                public function myFunction(' . $typehint . ' $one) {
+                }
+            }
+        ');
+
+        $this->fixture->whenICreateTheMockOf($className);
+        $this->fixture->whenIInvoke_WithTheArgument('myFunction', $value);
+    }
+
+    public function typehintProvider() {
+        $data = array(
+            array('array', array()),
+            array('\\DateTime', new \DateTime()),
+            array('\\Traversable', new \ArrayObject()),
+        );
+
+        if (PHP_VERSION_ID >= 50400) {
+            $data[] = array('callable', function () {});
+        }
+
+        return $data;
+    }
 }

--- a/src/rtens/mockster/MockProvider.php
+++ b/src/rtens/mockster/MockProvider.php
@@ -1,6 +1,6 @@
 <?php
 namespace rtens\mockster;
- 
+
 use watoki\factory\Injector;
 use watoki\factory\Provider;
 
@@ -95,11 +95,13 @@ class MockProvider implements Provider {
 
                 if ($param->isArray()) {
                     $typeHint = 'array ';
+                } else if (method_exists($param, 'isCallable') && $param->isCallable()) {
+                    $typeHint = 'callable ';
                 } else {
                     try {
                         $class = $param->getClass();
                     } catch (\ReflectionException $e) {
-                        $class = FALSE;
+                        $class = false;
                     }
 
                     if ($class) {
@@ -109,7 +111,7 @@ class MockProvider implements Provider {
 
                 if ($param->isDefaultValueAvailable()) {
                     $value = $param->getDefaultValue();
-                    $default = ' = ' . var_export($value, TRUE);
+                    $default = ' = ' . var_export($value, true);
                 } else if ($param->isOptional()) {
                     $default = ' = null';
                 }


### PR DESCRIPTION
For PHP >= 5.4 the typehint "callable" needs to be supported as otherwise Exceptions are thrown:

```
Declaration of Mock__RealClass_NoConstructor::map() should be compatible with RealClass::map(callable $callback)
```
